### PR TITLE
Alpha channel support in training

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -29,7 +29,7 @@ parser.add_argument("--camera", default="OPENCV", type=str)
 parser.add_argument("--colmap_executable", default="", type=str)
 parser.add_argument("--resize", action="store_true")
 parser.add_argument("--magick_executable", default="", type=str)
-parser.add_argument("--masks_path", "-s", type=str)
+parser.add_argument("--masks_path", type=str)
 args = parser.parse_args()
 colmap_command = '"{}"'.format(args.colmap_executable) if len(args.colmap_executable) > 0 else "colmap"
 magick_command = '"{}"'.format(args.magick_executable) if len(args.magick_executable) > 0 else "magick"
@@ -100,7 +100,6 @@ if args.masks_path is not None:
         --input_path " + args.source_path + "/distorted/sparse/0 \
         --output_path " + args.source_path + "/alpha_distorted_sparse_txt/ \
         --output_type TXT")
-    print(model_converter_cmd)
     exit_code = os.system(model_converter_cmd)
     if exit_code != 0:
         logging.error(f"model_converter failed with code {exit_code}. Exiting.")
@@ -120,7 +119,6 @@ if args.masks_path is not None:
         --input_path " + args.source_path + "/alpha_distorted_sparse_txt/ \
         --output_path " + args.source_path + "/alpha_undistorted_sparse \
         --output_type COLMAP")
-    print(seg_undist_cmd)
     exit_code = os.system(seg_undist_cmd)
     if exit_code != 0:
         logging.error(f"image_undistorter for segs failed with code {exit_code}. Exiting.")

--- a/convert.py
+++ b/convert.py
@@ -141,8 +141,9 @@ if args.masks_path is not None:
         img.putalpha(seg)
         img.save(f'{args.source_path}/images/{Path(seg_path).stem}.png')
 
+    all_masks_paths = glob(args.source_path + "/alpha_undistorted_sparse/alphas/*.png")
     with mp.Pool() as pool:
-        pool.imap_unrdered(concat_alpha, glob(args.source_path + "/alpha_undistorted_sparse/alphas/*.png"))
+        list(tqdm(pool.imap_unordered(concat_alpha, all_masks_paths), total=len(all_masks_paths)))
 
     # switch models
     remove_dir_if_exist(f'{args.source_path}/sparse_src/')

--- a/convert.py
+++ b/convert.py
@@ -134,14 +134,10 @@ if args.masks_path is not None:
     remove_dir_if_exist(f'{args.source_path}/images/')
     Path(f'{args.source_path}/images/').mkdir()
     for seg_path in tqdm(glob(args.source_path + "/alpha_undistorted_sparse/alphas/*.png")):
-        seg = np.array(Image.open(seg_path))
-        if seg.ndim == 2:
-            seg = seg[..., None]
-        if seg.ndim == 3:
-            seg = seg[..., :1]
-        img = np.array(Image.open(f'{args.source_path}/images_src/{Path(seg_path).stem}.jpg'))
-        img_alpha = np.concatenate([img, seg], axis=-1)
-        Image.fromarray(img_alpha).save(f'{args.source_path}/images/{Path(seg_path).stem}.png')
+        seg = Image.open(seg_path).convert('L')
+        img = Image.open(f'{args.source_path}/images_src/{Path(seg_path).stem}.jpg')
+        img.putalpha(seg)
+        img.save(f'{args.source_path}/images/{Path(seg_path).stem}.png')
 
     # switch models
     remove_dir_if_exist(f'{args.source_path}/sparse_src/')

--- a/convert.py
+++ b/convert.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from tqdm import tqdm
 from glob import glob
 import shutil
-import cv2
+from PIL import Image
 import numpy as np
 
 # This Python script is based on the shell converter script provided in the MipNerF 360 repository.
@@ -134,10 +134,14 @@ if args.masks_path is not None:
     remove_dir_if_exist(f'{args.source_path}/images/')
     Path(f'{args.source_path}/images/').mkdir()
     for seg_path in tqdm(glob(args.source_path + "/alpha_undistorted_sparse/alphas/*.png")):
-        seg = cv2.imread(seg_path)[..., :1]
-        img = cv2.imread(f'{args.source_path}/images_src/{Path(seg_path).stem}.jpg')
+        seg = np.array(Image.open(seg_path))
+        if seg.dim == 2:
+            seg = seg[..., None]
+        if seg.dim == 3:
+            seg = seg[..., :1]
+        img = np.array(Image.open(f'{args.source_path}/images_src/{Path(seg_path).stem}.jpg'))
         img_alpha = np.concatenate([img, seg], axis=-1)
-        cv2.imwrite(f'{args.source_path}/images/{Path(seg_path).stem}.png', img_alpha)
+        Image.fromarray(img_alpha).save(f'{args.source_path}/images/{Path(seg_path).stem}.png')
 
     # switch models
     remove_dir_if_exist(f'{args.source_path}/sparse_src/')

--- a/convert.py
+++ b/convert.py
@@ -13,6 +13,12 @@ import os
 import logging
 from argparse import ArgumentParser
 import shutil
+from pathlib import Path
+from tqdm import tqdm
+from glob import glob
+import shutil
+import cv2
+import numpy as np
 
 # This Python script is based on the shell converter script provided in the MipNerF 360 repository.
 parser = ArgumentParser("Colmap converter")

--- a/convert.py
+++ b/convert.py
@@ -135,9 +135,9 @@ if args.masks_path is not None:
     Path(f'{args.source_path}/images/').mkdir()
     for seg_path in tqdm(glob(args.source_path + "/alpha_undistorted_sparse/alphas/*.png")):
         seg = np.array(Image.open(seg_path))
-        if seg.dim == 2:
+        if seg.ndim == 2:
             seg = seg[..., None]
-        if seg.dim == 3:
+        if seg.ndim == 3:
             seg = seg[..., :1]
         img = np.array(Image.open(f'{args.source_path}/images_src/{Path(seg_path).stem}.jpg'))
         img_alpha = np.concatenate([img, seg], axis=-1)

--- a/scene/cameras.py
+++ b/scene/cameras.py
@@ -42,8 +42,10 @@ class Camera(nn.Module):
 
         if gt_alpha_mask is not None:
             self.original_image *= gt_alpha_mask.to(self.data_device)
+            self.gt_alpha_mask = gt_alpha_mask.to(self.data_device)
         else:
             self.original_image *= torch.ones((1, self.image_height, self.image_width), device=self.data_device)
+            self.gt_alpha_mask = None
 
         self.zfar = 100.0
         self.znear = 0.01

--- a/train.py
+++ b/train.py
@@ -89,6 +89,9 @@ def training(dataset, opt, pipe, testing_iterations, saving_iterations, checkpoi
 
         # Loss
         gt_image = viewpoint_cam.original_image.cuda()
+        # use alpha masking with background color used for rendering
+        if viewpoint_cam.gt_alpha_mask is not None:
+            gt_image = gt_image * viewpoint_cam.gt_alpha_mask + bg[:, None, None].expand_as(gt_image) * (1. - viewpoint_cam.gt_alpha_mask)
         Ll1 = l1_loss(image, gt_image)
         loss = (1.0 - opt.lambda_dssim) * Ll1 + opt.lambda_dssim * (1.0 - ssim(image, gt_image))
         loss.backward()

--- a/utils/camera_utils.py
+++ b/utils/camera_utils.py
@@ -23,13 +23,14 @@ def loadCam(args, id, cam_info, resolution_scale):
         resolution = round(orig_w/(resolution_scale * args.resolution)), round(orig_h/(resolution_scale * args.resolution))
     else:  # should be a type that converts to float
         if args.resolution == -1:
-            if orig_w > 1600:
+            max_length = max(orig_h, orig_w)
+            if max_length > 1600:
                 global WARNED
                 if not WARNED:
                     print("[ INFO ] Encountered quite large input images (>1.6K pixels width), rescaling to 1.6K.\n "
                         "If this is not desired, please explicitly specify '--resolution/-r' as 1")
                     WARNED = True
-                global_down = orig_w / 1600
+                global_down = max_length / 1600
             else:
                 global_down = 1
         else:

--- a/utils/camera_utils.py
+++ b/utils/camera_utils.py
@@ -44,7 +44,7 @@ def loadCam(args, id, cam_info, resolution_scale):
     gt_image = resized_image_rgb[:3, ...]
     loaded_mask = None
 
-    if resized_image_rgb.shape[1] == 4:
+    if resized_image_rgb.shape[0] == 4:
         loaded_mask = resized_image_rgb[3:4, ...]
 
     return Camera(colmap_id=cam_info.uid, R=cam_info.R, T=cam_info.T, 

--- a/utils/camera_utils.py
+++ b/utils/camera_utils.py
@@ -22,8 +22,8 @@ def loadCam(args, id, cam_info, resolution_scale):
     if args.resolution in [1, 2, 4, 8]:
         resolution = round(orig_w/(resolution_scale * args.resolution)), round(orig_h/(resolution_scale * args.resolution))
     else:  # should be a type that converts to float
+        max_length = max(orig_h, orig_w)
         if args.resolution == -1:
-            max_length = max(orig_h, orig_w)
             if max_length > 1600:
                 global WARNED
                 if not WARNED:
@@ -34,7 +34,7 @@ def loadCam(args, id, cam_info, resolution_scale):
             else:
                 global_down = 1
         else:
-            global_down = orig_w / args.resolution
+            global_down = max_length / args.resolution
 
         scale = float(global_down) * float(resolution_scale)
         resolution = (int(orig_w / scale), int(orig_h / scale))


### PR DESCRIPTION
- Modified `utils/camera_utils.py` to support loading and usage of alpha channels
- Updated `scene/cameras.py` to save `gt_alpha_mask` in `Camera` for usage in `train.py`
- Added alpha blending with background color in `train.py`
- Added `--masks_path` option in `convert.py` to support alpha masks

Best used with `--random_background` option to remove background splats

[Example for Gaussian Splat trained using this options](https://playcanvas.com/viewer?default&debug.grid=false&camera.multisample=false&camera.fov=66&ui.active=false&load=https://raw.githubusercontent.com/GalDude33/gsplats/main/groku_textseg.compressed.ply)